### PR TITLE
Gh pages patch 1

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@ kramdown:
   parse_block_html: true
 
 baseurl: "/foo_discord_rich/" 
-url: "https://theqwertiest.github.io"
+url: "https://s0hv.github.io"
 
 permalink: pretty
 
@@ -27,10 +27,10 @@ title: Discord Rich Presence Integration
 
 aux_links:
   "View on GitHub":
-    - "//github.com/theqwertiest/foo_discord_rich"
+    - "//github.com/s0hv/foo_discord_rich"
 
 color_scheme: "dark"
 
-footer_content: "Copyright &copy; 2018-2020 Yuri Shutenko.<br/>Distributed by an <a href=\"https://github.com/TheQwertiest/foo_discord_rich/blob/master/LICENSE\">MIT license.</a>"
+footer_content: "Copyright &copy; 2018-2023 Yuri Shutenko, s0hv.<br/>Distributed by an <a href=\"https://github.com/s0hv/foo_discord_rich/blob/master/LICENSE\">MIT license.</a>"
 
 ga_tracking: UA-154231909-3

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ permalink: /
 
 # Discord Rich Presence Integration
 {: .no_toc }
-[![version][version_badge]][changelog] [![Build status][appveyor_badge]](https://ci.appveyor.com/project/TheQwertiest/foo-discord-rich/branch/master) [![CodeFactor][codefactor_badge]](https://www.codefactor.io/repository/github/theqwertiest/foo_discord_rich/overview/master) [![Codacy Badge][codacy_badge]](https://app.codacy.com/app/qwertiest/foo_discord_rich?utm_source=github.com&utm_medium=referral&utm_content=TheQwertiest/foo_discord_rich&utm_campaign=Badge_Grade_Dashboard) 
+[![version][version_badge]][changelog] [![Build status][appveyor_badge]](https://ci.appveyor.com/project/s0hv/foo-discord-rich/branch/master) <!--[![CodeFactor][codefactor_badge]](https://www.codefactor.io/repository/github/theqwertiest/foo_discord_rich/overview/master) [![Codacy Badge][codacy_badge]](https://app.codacy.com/app/qwertiest/foo_discord_rich?utm_source=github.com&utm_medium=referral&utm_content=TheQwertiest/foo_discord_rich&utm_campaign=Badge_Grade_Dashboard) -->
 
 ## Table of contents
 {: .no_toc .text-delta }
@@ -17,7 +17,7 @@ permalink: /
 
 ---
 
-![foo_discord_rich](assets/img/foo_discord_rich.png)
+![foo_discord_rich](https://github.com/s0hv/foo_discord_rich/blob/gh-pages/assets/img/foo_discord_rich.png?raw=true)
 
 This is a component for the [foobar2000](https://www.foobar2000.org) audio player, which displays currently played track data via Discord Rich Presence.
 
@@ -32,10 +32,10 @@ Features:
 
 ## Links
 
-[Support thread](https://hydrogenaud.io/index.php/topic,116860.new.html)  
+<!--[Support thread](https://hydrogenaud.io/index.php/topic,116860.new.html)-->  
 [Changelog][changelog]  
 [Current tasks and plans][todo]  
-[Nightly build](https://ci.appveyor.com/api/projects/theqwertiest/foo-discord-rich/artifacts/_result%2FWin32_Release%2Ffoo_discord_rich.fb2k-component?branch=master&pr=false&job=Configuration%3A%20Release)
+<!--[Nightly build](https://ci.appveyor.com/api/projects/theqwertiest/foo-discord-rich/artifacts/_result%2FWin32_Release%2Ffoo_discord_rich.fb2k-component?branch=master&pr=false&job=Configuration%3A%20Release)-->
 
 ## Credits
 
@@ -43,8 +43,8 @@ Features:
 
 [changelog]: changelog.md
 [3rdparty_license]: third_party_notices.md
-[todo]: https://github.com/TheQwertiest/foo_discord_rich/projects/1
-[version_badge]: https://img.shields.io/github/release/theqwertiest/foo_discord_rich.svg
+[todo]: https://github.com/s0hv/foo_discord_rich/projects/1
+<!--[version_badge]: https://img.shields.io/github/release/theqwertiest/foo_discord_rich.svg
 [appveyor_badge]: https://ci.appveyor.com/api/projects/status/t5bhoxmfgavhq81m/branch/master?svg=true
 [codacy_badge]: https://api.codacy.com/project/badge/Grade/319298ca5bd64a739d1e70e3e27d59ab
-[codefactor_badge]: https://www.codefactor.io/repository/github/theqwertiest/foo_discord_rich/badge/master
+[codefactor_badge]: https://www.codefactor.io/repository/github/theqwertiest/foo_discord_rich/badge/master -->

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ permalink: /
 
 ---
 
-![foo_discord_rich](https://github.com/s0hv/foo_discord_rich/blob/gh-pages/assets/img/foo_discord_rich.png?raw=true)
+![foo_discord_rich](assets/img/foo_discord_rich.png)
 
 This is a component for the [foobar2000](https://www.foobar2000.org) audio player, which displays currently played track data via Discord Rich Presence.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -22,5 +22,5 @@ nav_order: 2
 
 ## Installation
 
-1. Download the [latest release](https://github.com/TheQwertiest/foo_discord_rich/releases/latest) (you only need `foo_discord_rich.fb2k-component`).
+1. Download the [latest release](https://github.com/s0hv/foo_discord_rich/releases/latest) (you only need `foo_discord_rich.fb2k-component`).
 1. Install the component using the [following instructions](http://wiki.hydrogenaud.io/index.php?title=Foobar2000:How_to_install_a_component).


### PR DESCRIPTION
Removed badges that reflect the source repo, _should_ fix the URLs on the Docs which still point to TheQwertiest's repo. Confused me for a minute before I realized what was happening.